### PR TITLE
Update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,4 +263,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.2.3
+   2.4.5


### PR DESCRIPTION
This PR updates bundler in order to fix `Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.` warning. See https://github.com/rubygems/rubygems/issues/5234 for more details.